### PR TITLE
fix: publish todo types under jonpham scope

### DIFF
--- a/.github/workflows/publish-todo-types.yml
+++ b/.github/workflows/publish-todo-types.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - "packages/todo-types/**"
+      - ".github/workflows/publish-todo-types.yml"
+      - "scripts/release/bump-todo-types-version.mjs"
 
 concurrency:
   group: publish-todo-types-${{ github.ref }}
@@ -33,19 +35,19 @@ jobs:
           node-version: "22"
           cache: "pnpm"
           registry-url: "https://npm.pkg.github.com"
-          scope: "@todo-skeleton"
+          scope: "@jonpham"
 
       - name: Install todo-types dependencies
-        run: pnpm install --filter @todo-skeleton/types... --frozen-lockfile --ignore-scripts
+        run: pnpm install --filter @jonpham/2026-project-todo-types... --frozen-lockfile --ignore-scripts
 
       - name: Lint package
-        run: pnpm --filter @todo-skeleton/types lint
+        run: pnpm --filter @jonpham/2026-project-todo-types lint
 
       - name: Test package
-        run: pnpm --filter @todo-skeleton/types test
+        run: pnpm --filter @jonpham/2026-project-todo-types test
 
       - name: Build package
-        run: pnpm --filter @todo-skeleton/types build
+        run: pnpm --filter @jonpham/2026-project-todo-types build
 
       - name: Check version reservation
         id: reservation
@@ -74,7 +76,7 @@ jobs:
         if: steps.reservation.outputs.has_reservation != 'true'
         run: |
           stderr_file="$(mktemp)"
-          if published_version="$(npm view @todo-skeleton/types version --registry https://npm.pkg.github.com 2>"$stderr_file")"; then
+          if published_version="$(npm view @jonpham/2026-project-todo-types version --registry https://npm.pkg.github.com 2>"$stderr_file")"; then
             :
           elif grep -Eq '(^npm error code E404\b|404 Not Found)' "$stderr_file"; then
             published_version=""
@@ -112,7 +114,7 @@ jobs:
         run: |
           stderr_file="$(mktemp)"
           reserved_version='${{ steps.reserve.outputs.version }}'
-          if published_version="$(npm view @todo-skeleton/types@"${reserved_version}" version --registry https://npm.pkg.github.com 2>"$stderr_file")"; then
+          if published_version="$(npm view @jonpham/2026-project-todo-types@"${reserved_version}" version --registry https://npm.pkg.github.com 2>"$stderr_file")"; then
             if [ "$published_version" != "$reserved_version" ]; then
               echo "Expected reserved version ${reserved_version}, got ${published_version}." >&2
               rm -f "$stderr_file"
@@ -138,7 +140,7 @@ jobs:
 
       - name: Publish package
         if: steps.registry.outputs.already_published != 'true'
-        run: pnpm --filter @todo-skeleton/types publish --no-git-checks
+        run: pnpm --filter @jonpham/2026-project-todo-types publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -156,6 +158,6 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
           echo "| --- | --- |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Package | @todo-skeleton/types |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Package | @jonpham/2026-project-todo-types |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Version | ${{ steps.reserve.outputs.version }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Registry | https://npm.pkg.github.com |" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/epics/MonorepoPwaApiIntegration/2026-04-28-W2-shared-types-package-design.md
+++ b/docs/epics/MonorepoPwaApiIntegration/2026-04-28-W2-shared-types-package-design.md
@@ -8,7 +8,7 @@
 ## Goal
 
 Establish a real shared-package workflow for the monorepo and its upstream app
-repositories by creating a monorepo-owned `@todo-skeleton/types` package,
+repositories by creating a monorepo-owned `@jonpham/2026-project-todo-types` package,
 publishing it automatically to GitHub Packages from CI on merges to `main`, and
 proving both upstream repos can consume the published artifact successfully.
 
@@ -37,7 +37,7 @@ depend on.
   - `CreateTodoDto`
   - `UpdateTodoDto`
 - Package build and package-level unit tests
-- GitHub Packages publication for `@todo-skeleton/types`
+- GitHub Packages publication for `@jonpham/2026-project-todo-types`
 - GitHub Actions workflow that publishes on merges to monorepo `main` when
   `packages/todo-types` changes
 - Deterministic package version bumping for automatic publish flow
@@ -66,7 +66,7 @@ depend on.
 
 ### Upstream repos own
 
-- Their dependency declaration on `@todo-skeleton/types`
+- Their dependency declaration on `@jonpham/2026-project-todo-types`
 - Their registry authentication/config for GitHub Packages consumption
 - Code changes needed to replace duplicated wire-contract types with imports from
   the package
@@ -80,7 +80,7 @@ repos first, then return to the monorepo through normal subtree sync.
 
 ### Package name and registry
 
-- Package name: `@todo-skeleton/types`
+- Package name: `@jonpham/2026-project-todo-types`
 - Registry: GitHub Packages
 - Initial version: `0.1.0`
 

--- a/docs/epics/MonorepoPwaApiIntegration/2026-04-28-W2-shared-types-package-implementation-plan.md
+++ b/docs/epics/MonorepoPwaApiIntegration/2026-04-28-W2-shared-types-package-implementation-plan.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Build `@todo-skeleton/types` as a monorepo-owned package, publish it automatically to GitHub Packages from monorepo CI on merges to `main`, and prove both upstream app repos can consume explicit published versions successfully.
+**Goal:** Build `@jonpham/2026-project-todo-types` as a monorepo-owned package, publish it automatically to GitHub Packages from monorepo CI on merges to `main`, and prove both upstream app repos can consume explicit published versions successfully.
 
 **Architecture:** The monorepo is the package producer and release owner. `packages/todo-types` defines the canonical wire-contract schemas and types, GitHub Actions publishes patch bumps to GitHub Packages, and both upstream repos update to consume the published artifact rather than local workspace links. Upstream changes merge first in their own repos, then return to the monorepo via normal subtree sync.
 
@@ -134,7 +134,7 @@ describe("UpdateTodoDtoSchema", () => {
 
 - [ ] **Step 2: Run the package test to verify it fails**
 
-Run: `pnpm --dir /Users/jp/code/_boilerplate/2026-project-todo/2026-project-todo-skeleton-monorepo --filter @todo-skeleton/types test`
+Run: `pnpm --dir /Users/jp/code/_boilerplate/2026-project-todo/2026-project-todo-skeleton-monorepo --filter @jonpham/2026-project-todo-types test`
 
 Expected: FAIL with package not found or missing source files.
 
@@ -142,7 +142,7 @@ Expected: FAIL with package not found or missing source files.
 
 ```json
 {
-  "name": "@todo-skeleton/types",
+  "name": "@jonpham/2026-project-todo-types",
   "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -183,7 +183,7 @@ Expected: FAIL with package not found or missing source files.
 ```
 
 ```ini
-@todo-skeleton:registry=https://npm.pkg.github.com
+@jonpham:registry=https://npm.pkg.github.com
 ```
 
 - [ ] **Step 4: Implement the minimal schema source**
@@ -244,13 +244,13 @@ Run: `pnpm install`
 
 Expected: lockfile updates and workspace package becomes resolvable.
 
-Run: `pnpm --filter @todo-skeleton/types test`
+Run: `pnpm --filter @jonpham/2026-project-todo-types test`
 
 Expected: PASS for all schema tests.
 
 - [ ] **Step 7: Build the package**
 
-Run: `pnpm --filter @todo-skeleton/types build`
+Run: `pnpm --filter @jonpham/2026-project-todo-types build`
 
 Expected: PASS and `packages/todo-types/dist/index.js` plus `index.d.ts` exist.
 
@@ -304,6 +304,8 @@ on:
       - "packages/todo-types/**"
       - ".github/workflows/publish-todo-types.yml"
       - "scripts/release/bump-todo-types-version.mjs"
+      - ".github/workflows/publish-todo-types.yml"
+      - "scripts/release/bump-todo-types-version.mjs"
 
 jobs:
   publish:
@@ -324,14 +326,14 @@ jobs:
         with:
           node-version: 22
           registry-url: https://npm.pkg.github.com
-          scope: "@todo-skeleton"
+          scope: "@jonpham"
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter @todo-skeleton/types test
-      - run: pnpm --filter @todo-skeleton/types build
+      - run: pnpm --filter @jonpham/2026-project-todo-types test
+      - run: pnpm --filter @jonpham/2026-project-todo-types build
       - run: node scripts/release/bump-todo-types-version.mjs
-      - run: pnpm --filter @todo-skeleton/types publish --no-git-checks
+      - run: pnpm --filter @jonpham/2026-project-todo-types publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -339,11 +341,11 @@ jobs:
 - [ ] **Step 4: Add package workflow documentation**
 
 ```md
-# `@todo-skeleton/types`
+# `@jonpham/2026-project-todo-types`
 
 ## Publish behavior
 
-- Trigger: push to `main` when `packages/todo-types/**` changes
+- Trigger: push to `main` when `packages/todo-types/**`, the publish workflow, or the release helper changes
 - Versioning: automatic patch bump
 - Registry: GitHub Packages
 
@@ -351,7 +353,7 @@ jobs:
 
 Add to `.npmrc`:
 
-@todo-skeleton:registry=https://npm.pkg.github.com
+@jonpham:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:\_authToken=${GITHUB_TOKEN}
 ```
 
@@ -403,7 +405,7 @@ git commit -m "feat: publish todo types to github packages"
 Use these exact adjustments:
 
 ```md
-- GitHub Packages publication for `@todo-skeleton/types`
+- GitHub Packages publication for `@jonpham/2026-project-todo-types`
 - CI publication on merges to `main`
 - Automatic patch bump release behavior
 - Upstream PWA repo consumes the published package
@@ -439,7 +441,7 @@ git commit -m "docs: align GH42 with published package workflow"
 - [ ] **Step 1: Add registry config in the upstream PWA repo**
 
 ```ini
-@todo-skeleton:registry=https://npm.pkg.github.com
+@jonpham:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
 ```
 
@@ -448,7 +450,7 @@ git commit -m "docs: align GH42 with published package workflow"
 ```json
 {
   "dependencies": {
-    "@todo-skeleton/types": "0.1.1"
+    "@jonpham/2026-project-todo-types": "0.1.1"
   }
 }
 ```
@@ -458,7 +460,7 @@ Use the actual version published by Task 2 instead of hard-coding `0.1.1`.
 - [ ] **Step 3: Replace local wire type declarations with imports**
 
 ```ts
-import type { TodoItem } from "@todo-skeleton/types";
+import type { TodoItem } from "@jonpham/2026-project-todo-types";
 
 export type TodoAction =
   | { type: "LOAD_TODOS"; payload: TodoItem[] }
@@ -476,7 +478,7 @@ Use a pattern equivalent to:
 
 ```dockerfile
 ARG GITHUB_TOKEN
-RUN printf "@todo-skeleton:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=%s\n" "$GITHUB_TOKEN" > .npmrc
+RUN printf "@jonpham:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=%s\n" "$GITHUB_TOKEN" > .npmrc
 RUN pnpm install --frozen-lockfile
 RUN rm .npmrc
 ```
@@ -487,7 +489,7 @@ If the current Docker build never installs private packages in CI or local image
 
 Run: `pnpm install`
 
-Expected: PASS and `@todo-skeleton/types` resolves from GitHub Packages.
+Expected: PASS and `@jonpham/2026-project-todo-types` resolves from GitHub Packages.
 
 Run: `pnpm build`
 
@@ -517,7 +519,7 @@ git commit -m "feat: consume shared todo types package"
 - [ ] **Step 1: Add registry config in the upstream API repo**
 
 ```ini
-@todo-skeleton:registry=https://npm.pkg.github.com
+@jonpham:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
 ```
 
@@ -526,7 +528,7 @@ git commit -m "feat: consume shared todo types package"
 ```json
 {
   "dependencies": {
-    "@todo-skeleton/types": "0.1.1"
+    "@jonpham/2026-project-todo-types": "0.1.1"
   }
 }
 ```
@@ -536,7 +538,7 @@ Use the actual version published by Task 2.
 - [ ] **Step 3: Update the API entity/response boundary to import shared types**
 
 ```ts
-import type { TodoItem } from "@todo-skeleton/types";
+import type { TodoItem } from "@jonpham/2026-project-todo-types";
 
 export class TodoEntity implements TodoItem {
   id!: string;
@@ -555,7 +557,7 @@ import type {
   CreateTodoDto,
   TodoItem,
   UpdateTodoDto,
-} from "@todo-skeleton/types";
+} from "@jonpham/2026-project-todo-types";
 ```
 
 Use the shared types for response typing and DTO type references where it does not conflict with NestJS decorator-based classes.
@@ -568,7 +570,7 @@ Use the same temporary `.npmrc` pattern as Task 4 if the build installs private 
 
 Run: `pnpm install`
 
-Expected: PASS and `@todo-skeleton/types` resolves from GitHub Packages.
+Expected: PASS and `@jonpham/2026-project-todo-types` resolves from GitHub Packages.
 
 Run: `pnpm build`
 
@@ -657,19 +659,19 @@ git -C /Users/jp/code/_boilerplate/2026-project-todo/2026-project-todo-skeleton-
 
 - [ ] **Step 1: Verify monorepo package tests**
 
-Run: `pnpm --filter @todo-skeleton/types test`
+Run: `pnpm --filter @jonpham/2026-project-todo-types test`
 
 Expected: PASS.
 
 - [ ] **Step 2: Verify monorepo package build**
 
-Run: `pnpm --filter @todo-skeleton/types build`
+Run: `pnpm --filter @jonpham/2026-project-todo-types build`
 
 Expected: PASS.
 
 - [ ] **Step 3: Verify published package is visible**
 
-Run: `npm view @todo-skeleton/types --registry=https://npm.pkg.github.com`
+Run: `npm view @jonpham/2026-project-todo-types --registry=https://npm.pkg.github.com`
 
 Expected: PASS and shows the latest published version. If auth is required locally, set `NODE_AUTH_TOKEN` first.
 
@@ -725,5 +727,5 @@ git commit -m "docs: close W2 shared types workstream"
 ### Type consistency
 
 - Package exports are consistently named `TodoItem`, `CreateTodoDto`, and `UpdateTodoDto`
-- The package path is consistently `@todo-skeleton/types`
-- The release trigger is consistently “push to monorepo `main` when `packages/todo-types/**` changes”
+- The package path is consistently `@jonpham/2026-project-todo-types`
+- The release trigger is consistently “push to monorepo `main` when package source or publish infrastructure changes”

--- a/docs/features/[TODO]GH37_pwa-api-client-sync-queue.md
+++ b/docs/features/[TODO]GH37_pwa-api-client-sync-queue.md
@@ -41,7 +41,7 @@ implementation the app uses — it is not a conditional hook call.
 **Excluded:**
 
 - Changes to `useTodoWorker` (remains pure local, no API awareness)
-- Changes to `@todo-skeleton/types` (wire types — Phase W2)
+- Changes to `@jonpham/2026-project-todo-types` (wire types — Phase W2)
 - L3 system integration tests and L4 E2E (Phase 7)
 - Authentication
 - Rate limiting / retry backoff (TODOS.md — Phase 2)
@@ -49,7 +49,7 @@ implementation the app uses — it is not a conditional hook call.
 ## Dependencies
 
 - Phase 5 complete (NestJS API running at `localhost:3001` via Docker Compose)
-- `@todo-skeleton/types` workspace package exists with `TodoItem`, `CreateTodoDto` (with `id?: string`), `UpdateTodoDto`
+- `@jonpham/2026-project-todo-types` workspace package exists with `TodoItem`, `CreateTodoDto` (with `id?: string`), `UpdateTodoDto`
 
 ## Acceptance Criteria
 
@@ -109,7 +109,7 @@ L1 tests live at `apps/todo-pwa-vite/src/hooks/useTodoApi.test.ts`. They mock `f
 
 ## Assumptions
 
-- `@todo-skeleton/types` is available as a workspace dependency with `TodoItem` and `CreateTodoDto { id?: string, description: string }`.
+- `@jonpham/2026-project-todo-types` is available as a workspace dependency with `TodoItem` and `CreateTodoDto { id?: string, description: string }`.
 - NestJS API accepts a client-provided `id` in the POST body (via `CreateTodoDto id?` — upstream change tracked in W1 upstream issue).
 - The API uses `PATCH /v1/todos/:id` for updates and `DELETE /v1/todos/:id` for deletes — same IDs as the client-generated UUIDs.
 - `useTodoWorker` is not modified in this phase; it continues to return `offline: false` to satisfy `TodoHook`.

--- a/docs/features/[TODO]GH40_pwa-api-integration-tests.md
+++ b/docs/features/[TODO]GH40_pwa-api-integration-tests.md
@@ -7,8 +7,8 @@ step_gating: false
 epic_issue: null
   ["jonpham/2026-project-todo-pwa-vite", "jonpham/2026-project-todo-api-nestjs"]
   [
-    "jonpham/2026-project-todo-pwa-vite#3",
-    "jonpham/2026-project-todo-api-nestjs#2",
+  "jonpham/2026-project-todo-pwa-vite#3",
+  "jonpham/2026-project-todo-api-nestjs#2",
   ]
 branch: null
 pr: null
@@ -59,7 +59,7 @@ yet that justifies inter-unit tests beyond what L1 already covers.
 
 - Phase 6 complete (`useTodoApi` implemented with L1 queue tests)
 - Docker Compose stack functional (NestJS + nginx + SQLite volume)
-- `@todo-skeleton/types` with Zod schemas
+- `@jonpham/2026-project-todo-types` with Zod schemas
 
 ## Acceptance Criteria
 
@@ -71,7 +71,7 @@ yet that justifies inter-unit tests beyond what L1 already covers.
 - [ ] L3: each test isolated — `afterEach` deletes all rows; tests do not share state
 - [ ] L4: `docker compose up`, create todo via PWA UI, verify todo persists in SQLite after `docker compose down && docker compose up`
 - [ ] L4: offline create cycle — `page.context().setOffline(true)`, create todo, verify `syncStatus: 'pending'` in UI; `page.context().setOffline(false)`, verify `syncStatus: 'synced'`
-- [ ] Shared types: `pnpm --filter @todo-skeleton/types test` passes Zod schema validation for `TodoItem`, `CreateTodoDto` (with and without id), `UpdateTodoDto`
+- [ ] Shared types: `pnpm --filter @jonpham/2026-project-todo-types test` passes Zod schema validation for `TodoItem`, `CreateTodoDto` (with and without id), `UpdateTodoDto`
 - [ ] All existing L1 tests continue to pass (no regressions)
 
 ## Steps
@@ -90,7 +90,7 @@ yet that justifies inter-unit tests beyond what L1 already covers.
 - **L4 offline mechanism:** `page.context().setOffline(true)` is the only correct Playwright approach. It sets `navigator.onLine = false` AND fires the `offline` event. `page.route()` alone intercepts requests but does not update `navigator.onLine` — the `online` event listener in `useTodoApi` would never fire on reconnect.
 - **L4 Docker Compose setup:** `e2e-docker/` runs against a `docker compose up` stack. Tests use `baseURL: http://localhost` (nginx port 80). SQLite volume must be named (not anonymous) to survive compose down/up — verify in `docker-compose.yml`.
 - **`/health` endpoint:** Upstream change tracked in W1 upstream issue (`jonpham/2026-project-todo-api-nestjs`). L3 test for `/health` depends on that upstream PR being merged and synced into monorepo before this phase runs.
-- **Shared types Zod tests:** Live at `packages/todo-types/src/index.test.ts`. Run via `pnpm --filter @todo-skeleton/types test`. No mocks — pure schema validation.
+- **Shared types Zod tests:** Live at `packages/todo-types/src/index.test.ts`. Run via `pnpm --filter @jonpham/2026-project-todo-types test`. No mocks — pure schema validation.
 
 ## Test Strategy
 

--- a/docs/features/[TODO]GH42_shared-types-package.md
+++ b/docs/features/[TODO]GH42_shared-types-package.md
@@ -15,7 +15,7 @@ pr: null
 completed_at: null
 ---
 
-# Phase 9 — Shared Types Package `@todo-skeleton/types` (W2)
+# Phase 9 — Shared Types Package `@jonpham/2026-project-todo-types` (W2)
 
 ## Context
 
@@ -25,8 +25,9 @@ and upstream consumption so the shared wire contract can be reused by the standa
 
 The PWA and NestJS API share a wire contract: `TodoItem`, `CreateTodoDto`, and
 `UpdateTodoDto` must stay aligned across implementations. This phase defines the canonical Zod
-schemas and inferred TypeScript types in `@todo-skeleton/types`, publishes that package to
-GitHub Packages from CI on pushes to `main` when `packages/todo-types/**` changes, and updates
+schemas and inferred TypeScript types in `@jonpham/2026-project-todo-types`, publishes that package to
+GitHub Packages from CI on pushes to `main` when the package source or publish infrastructure
+changes, and updates
 both standalone consumers to depend on the published package.
 
 The package remains intentionally narrow. It owns API wire types only. UI-specific types
@@ -37,13 +38,14 @@ stays in the API layer.
 
 **Included:**
 
-- `packages/todo-types/` — source package `@todo-skeleton/types` in the monorepo
+- `packages/todo-types/` — source package `@jonpham/2026-project-todo-types` in the monorepo
 - Zod schemas for `TodoItem`, `CreateTodoDto` (with `id?: string`), `UpdateTodoDto`
 - TypeScript types inferred via `z.infer<>` — no separate type declarations
 - L1 Vitest schema validation tests (co-located in package)
-- GitHub Packages publish configuration for `@todo-skeleton/types`
+- GitHub Packages publish configuration for `@jonpham/2026-project-todo-types`
 - Release workflow in GitHub Actions that runs on pushes to `main` when
-  `packages/todo-types/**` changes
+  `packages/todo-types/**`, `.github/workflows/publish-todo-types.yml`, or
+  `scripts/release/bump-todo-types-version.mjs` changes
 - Automatic patch version bump and package publication behavior in CI
 - Upstream consumer integration in `2026-project-todo-pwa-vite` and
   `2026-project-todo-api-nestjs` using pinned explicit published versions of the GitHub
@@ -74,13 +76,13 @@ stays in the API layer.
 
 ## Acceptance Criteria
 
-- [ ] `packages/todo-types/` exists with `package.json` name `@todo-skeleton/types`
+- [ ] `packages/todo-types/` exists with `package.json` name `@jonpham/2026-project-todo-types`
 - [ ] Zod schemas exported: `TodoItemSchema`, `CreateTodoDtoSchema`, `UpdateTodoDtoSchema`
 - [ ] TypeScript types exported: `TodoItem`, `CreateTodoDto`, `UpdateTodoDto` (all via `z.infer<>`)
-- [ ] `pnpm --filter @todo-skeleton/types test` passes: valid payloads pass, invalid payloads (missing description, wrong types) fail with correct Zod errors
+- [ ] `pnpm --filter @jonpham/2026-project-todo-types test` passes: valid payloads pass, invalid payloads (missing description, wrong types) fail with correct Zod errors
 - [ ] `packages/todo-types/package.json` is configured for GitHub Packages publication
-- [ ] A GitHub Actions workflow publishes on pushes to `main` when
-      `packages/todo-types/**` changes
+- [ ] A GitHub Actions workflow publishes on pushes to `main` when package source or publish
+      infrastructure changes
 - [ ] The committed `packages/todo-types/package.json` version remains at the baseline value;
       patch version mutation happens only inside CI for publication
 - [ ] The publish job authenticates with the repository `GITHUB_TOKEN` using `contents: write`
@@ -88,10 +90,10 @@ stays in the API layer.
 - [ ] Reruns for the same qualifying commit reuse the commit-reserved version and skip publish
       cleanly when that version already exists in GitHub Packages
 - [ ] `2026-project-todo-pwa-vite` installs a pinned explicit published version of
-      `@todo-skeleton/types` from GitHub Packages, not a floating range or tag, with scoped registry
+      `@jonpham/2026-project-todo-types` from GitHub Packages, not a floating range or tag, with scoped registry
       config and auth in place, and its build passes against that artifact
 - [ ] `2026-project-todo-api-nestjs` installs a pinned explicit published version of
-      `@todo-skeleton/types` from GitHub Packages, not a floating range or tag, with scoped registry
+      `@jonpham/2026-project-todo-types` from GitHub Packages, not a floating range or tag, with scoped registry
       config and auth in place, and its build passes against that artifact
 - [ ] Subtree sync brings the upstream consumer integration back into the monorepo in the
       approved W2 flow
@@ -105,24 +107,26 @@ stays in the API layer.
 - [x] **Step 2** — Configure `package.json` for GitHub Packages publication, including package
       name, registry-facing metadata, and versioning expectations for CI-driven patch releases
 - [x] **Step 3** — Add a GitHub Actions workflow that triggers on pushes to `main` when
-      `packages/todo-types/**` changes; build, test, patch-bump, and publish the package
+      package source or publish infrastructure changes; build, test, patch-bump, and publish the
+      package
 - [x] **Step 4** — Keep the committed package manifest at its baseline version and mutate the
       patch version only inside CI for publication
 - [x] **Step 5** — Ensure the release flow automatically publishes the commit-scoped reserved
-      patch version for each qualifying push to `main` when `packages/todo-types/**` changes, and
+      patch version for each qualifying push to `main` when package source or publish
+      infrastructure changes, and
       reruns for the same commit reuse that reserved version and skip publish cleanly if the version
       already exists in GitHub Packages
 - [ ] **Step 6** — Update `2026-project-todo-pwa-vite` to configure scoped GitHub Packages
-      registry/auth, install a pinned explicit published version of `@todo-skeleton/types`, and
+      registry/auth, install a pinned explicit published version of `@jonpham/2026-project-todo-types`, and
       switch imports to the published package contract
 - [ ] **Step 7** — Update `2026-project-todo-api-nestjs` to configure scoped GitHub Packages
-      registry/auth, install a pinned explicit published version of `@todo-skeleton/types`, and
+      registry/auth, install a pinned explicit published version of `@jonpham/2026-project-todo-types`, and
       switch imports to the published package contract
 - [ ] **Step 8** — Subtree sync the upstream consumer changes back into the monorepo as the
       approved W2 follow-through
-- [ ] **Step 9** — Verify the publish workflow is scoped only to pushes to `main` when
-      `packages/todo-types/**` changes, and verify the standalone repos can authenticate, install,
-      and build against the published package
+- [ ] **Step 9** — Verify the publish workflow is scoped only to pushes to `main` when package
+      source or publish infrastructure changes, and verify the standalone repos can authenticate,
+      install, and build against the published package
 - [ ] **Step 10** — Monorepo-local consumer wiring or build checks may be used as supporting
       verification context, but they are not the primary W2 success target
 - [ ] **Step 11** — Update this feature doc to DONE after Tasks 4-7 land
@@ -133,9 +137,9 @@ stays in the API layer.
   is the source of truth and the exported type is derived from it.
 - **Registry target:** The approved publication target is GitHub Packages, not npmjs. The package
   metadata and consumer setup should assume scoped package installation from GitHub's registry.
-- **Workflow trigger breadth:** The earlier plan draft had conflicting trigger scopes. The
-  approved W2 design is narrower and should be implemented exactly: publish on pushes to `main`
-  when `packages/todo-types/**` changes.
+- **Workflow trigger breadth:** Publish only on pushes to `main` when the package source or the
+  publish infrastructure changes. The workflow and release helper are included so publication
+  fixes can bootstrap or repair the package without requiring a meaningless package source edit.
 - **Publish auth model:** The monorepo publish job uses the repository `GITHUB_TOKEN` with
   `contents: write` and `packages: write`. Extra publish secrets are not required for this
   workflow.
@@ -143,13 +147,13 @@ stays in the API layer.
   stays at the baseline value in git. Patch version mutation happens only inside CI as part of
   preparing the publish artifact.
 - **Automatic patch release behavior:** W2 uses a single release model: every qualifying push to
-  `main` when `packages/todo-types/**` changes publishes the commit-scoped reserved patch
+  `main` when package source or publish infrastructure changes publishes the commit-scoped reserved patch
   version to GitHub Packages without manual branch-side version editing. That reserved version
   makes reruns for the same commit idempotent, and reruns should skip publish cleanly when that
   version already exists in GitHub Packages. The reservation tag is an implementation detail of
   the automation.
 - **Upstream dependency pinning:** The standalone repos should consume pinned explicit published
-  versions of `@todo-skeleton/types`. They should not depend on floating semver ranges, dist-tags,
+  versions of `@jonpham/2026-project-todo-types`. They should not depend on floating semver ranges, dist-tags,
   or other moving references for this W2 integration.
 - **Downstream registry auth:** The standalone repos also need scoped GitHub Packages registry
   configuration and authentication in their npm or pnpm setup; pinning the dependency alone is
@@ -159,10 +163,10 @@ stays in the API layer.
   workspace linking is useful for development and spot checks, but it is not the primary
   deliverable.
 - **NestJS DTO classes vs Zod:** NestJS can keep class-validator-based request DTOs if needed.
-  `@todo-skeleton/types` defines the wire contract and shared TS types; it does not require the
+  `@jonpham/2026-project-todo-types` defines the wire contract and shared TS types; it does not require the
   API to replace all app-local validation classes.
 - **Docker and CI auth:** Any downstream Dockerfiles or CI jobs that install
-  `@todo-skeleton/types` from GitHub Packages will need registry authentication wired through the
+  `@jonpham/2026-project-todo-types` from GitHub Packages will need registry authentication wired through the
   appropriate npm config or token injection.
 - **`id?: string` in `CreateTodoDtoSchema`:** `id` remains optional and must validate as a UUID
   when present.

--- a/docs/initiatives/MonorepoPwaApiIntegration/GSTACK-jp-main-design-20260427-230905.md
+++ b/docs/initiatives/MonorepoPwaApiIntegration/GSTACK-jp-main-design-20260427-230905.md
@@ -278,7 +278,7 @@ These can proceed concurrently once the shared types package (Workstream 2) exis
       integration or `railway up`, not Pulumi-managed)
 - [ ] `docker-compose.yml` (default): uses upstream Dockerfiles with standalone build
       context + published npm packages. This is the primary integration path — it tests
-      the same build as Railway/Cloudflare Pages. Requires `@todo-skeleton/types` to be
+      the same build as Railway/Cloudflare Pages. Requires `@jonpham/2026-project-todo-types` to be
       published before `docker compose up` works.
 - [ ] `docker-compose.local.yml` (opt-in override): changes build context to monorepo
       root and uses `Dockerfile.local` for each app. Invoked with:
@@ -309,7 +309,7 @@ These can proceed concurrently once the shared types package (Workstream 2) exis
 
 **Workstream 2: Shared Types Package**
 
-Pre-requisite: Verify npm scope availability for `@todo-skeleton` before starting.
+Pre-requisite: Verify npm scope availability for `@jonpham` before starting.
 Fallback scopes if taken: `@todo-mono`, `@jp-todo`. This is a hard blocker — pick
 and reserve the scope first, then update all references in the doc.
 
@@ -330,22 +330,22 @@ Minimum type shapes (derived from existing NestJS entities and PWA types):
 PWA extension (lives in `apps/todo-pwa-vite/src/types/todo.ts`, imports base from package):
 
 ```typescript
-import type { TodoItem } from "@todo-skeleton/types";
+import type { TodoItem } from "@jonpham/2026-project-todo-types";
 export type SyncStatus = "pending" | "synced" | "failed";
 export type UiTodo = TodoItem & { syncStatus: SyncStatus };
 ```
 
-- [ ] Verify and reserve npm package scope (`@todo-skeleton` or fallback)
+- [ ] Verify and reserve npm package scope (`@jonpham` or fallback)
 - [ ] Scaffold `packages/todo-types` with `TodoItem`, `CreateTodoDto`, `UpdateTodoDto`
       using the field table above
 - [ ] Add Zod schemas alongside TypeScript types — use `z.infer<typeof Schema>` to derive
       TS types from Zod schemas (single source of truth; prevents interface/schema drift)
 - [ ] Configure publishing to npm public
-- [ ] Add `"@todo-skeleton/types": "workspace:*"` to both
+- [ ] Add `"@jonpham/2026-project-todo-types": "workspace:*"` to both
       `apps/todo-pwa-vite/package.json` and `apps/todo-api-nestjs/package.json`
       (pnpm workspace link — no publish needed locally)
 - [ ] Update `apps/todo-pwa-vite/src/types/todo.ts` to import `TodoItem` from
-      `@todo-skeleton/types` and extend with `UiTodo` — do NOT delete the file
+      `@jonpham/2026-project-todo-types` and extend with `UiTodo` — do NOT delete the file
 - [ ] After publish: update upstream repos to install the versioned npm package
       (replace `workspace:*` with `"^1.0.0"` in their standalone `package.json`)
 
@@ -435,7 +435,7 @@ Four levels defined. Each level has a clear scope and isolation contract:
 - Tests: happy-path CRUD (create todo → verify persisted via API → reload → still there)
   - offline-sync smoke (go offline → create todo → go online → assert API received it)
 - Separate Playwright config or project for `e2e-docker` to distinguish from offline L4 tests
-- `@todo-skeleton/types` must be published before L4 CI can run (Docker build dependency)
+- `@jonpham/2026-project-todo-types` must be published before L4 CI can run (Docker build dependency)
 
 **Coverage gaps closed by Phase 1:**
 
@@ -445,7 +445,7 @@ Four levels defined. Each level has a clear scope and isolation contract:
 
 ### Open Questions
 
-1. **Published types package scope**: npm public, package name `@todo-skeleton/types`.
+1. **Published types package scope**: npm public, package name `@jonpham/2026-project-todo-types`.
    Fallbacks if scope taken: `@todo-mono/types`, `@jp-todo/types`. Verify availability
    before starting Workstream 2 — this is a hard blocker.
 2. **PWA on k8s**: Stays on Cloudflare Pages long-term. No k8s manifest needed for the PWA.
@@ -481,7 +481,7 @@ Four levels defined. Each level has a clear scope and isolation contract:
   primary staging and demo target; must work before Railway is considered ready
 - PWA: Cloudflare Pages (existing pipeline, no change) — built with `VITE_TODO_API_URL=https://...railway.app`
 - API: Railway (new) — deployed via Railway GitHub integration or `railway up`; NOT managed by Pulumi
-- Shared types: Published to npm as `@todo-skeleton/types` (fallbacks: `@todo-mono/types`, `@jp-todo/types`)
+- Shared types: Published to npm as `@jonpham/2026-project-todo-types` (fallbacks: `@todo-mono/types`, `@jp-todo/types`)
 - Cloudflare DNS: Pulumi adds CNAME record pointing to Railway URL (Pulumi manages Cloudflare only)
 - k8s: Deployed to self-hosted cluster via `helm install` — no CI automation in Phase 1
 
@@ -535,7 +535,7 @@ Key architectural decisions made during eng review (2026-04-28):
 
 - D5: VITE_TODO_MODE eliminated; single-build offline-first PWA with S2 queue+flush sync
 - D6: findOrFail helper extracted in todos.service.ts (upstream first)
-- D7: @todo-skeleton/types = narrow wire contract; apps extend locally (UiTodo)
+- D7: @jonpham/2026-project-todo-types = narrow wire contract; apps extend locally (UiTodo)
 - D8: useTodoApi.spec.ts with full sync queue coverage in Phase 1 (TDD — not deferred)
 - D9a: L3 isolation via test.db + afterEach deleteMany
 - D9b: L4 Docker Compose + Playwright in Phase 1

--- a/docs/initiatives/MonorepoPwaApiIntegration/GSTACK-jp-main-eng-review-test-plan-20260428-124154.md
+++ b/docs/initiatives/MonorepoPwaApiIntegration/GSTACK-jp-main-eng-review-test-plan-20260428-124154.md
@@ -67,7 +67,7 @@ Repo: jonpham/2026-project-todo-skeleton-monorepo
 1. **Offline create → sync to API:** User creates todo while offline, comes back online, todo persists in API and survives page reload — verifies full offline-first cycle end-to-end
 2. **Docker Compose full stack (L4):** `docker compose up`, create todo via PWA UI, todo persists in SQLite after `docker compose down && docker compose up` — verifies nginx proxy, Docker networking, and volume persistence
 3. **NestJS smoke test (L3):** POST → GET → DELETE cycle against real SQLite — verifies Prisma migrations ran, queries work, and cleanup is clean between tests
-4. **Shared types contract:** Both PWA and NestJS compile without errors with @todo-skeleton/types installed as workspace dependency — verifies the package shape matches both consumers
+4. **Shared types contract:** Both PWA and NestJS compile without errors with @jonpham/2026-project-todo-types installed as workspace dependency — verifies the package shape matches both consumers
 
 ## Test Levels Summary
 

--- a/docs/packages/todo-types.md
+++ b/docs/packages/todo-types.md
@@ -1,16 +1,16 @@
-# `@todo-skeleton/types`
+# `@jonpham/2026-project-todo-types`
 
-`@todo-skeleton/types` is published from the monorepo to GitHub Packages. The package is the shared wire-contract source for Todo schemas and types.
+`@jonpham/2026-project-todo-types` is published from the monorepo to GitHub Packages. The package is the shared wire-contract source for Todo schemas and types.
 
 ## Publish behavior
 
 - Workflow: `.github/workflows/publish-todo-types.yml`
-- Trigger: push to `main` only when `packages/todo-types/**` changes
+- Trigger: push to `main` when `packages/todo-types/**`, the publish workflow, or the release helper changes
 - Registry: `https://npm.pkg.github.com`
-- Package name: `@todo-skeleton/types`
+- Package name: `@jonpham/2026-project-todo-types`
 - Versioning: patch-only auto bump during publish
 
-The workflow installs only `@todo-skeleton/types` and its dependency closure, with lifecycle scripts disabled so unrelated monorepo hooks do not run on the publish path. It then runs package lint/test/build, checks for a commit-scoped version reservation tag, looks up the latest published package version in GitHub Packages when needed, reserves the chosen version for `github.sha`, and publishes that reserved version. If the same commit is rerun, the workflow reuses the existing reservation instead of minting another patch version. It then checks whether that reserved version is already present in GitHub Packages: if it is already present, the workflow skips publish cleanly; if it is not present, the workflow publishes the same reserved version. If the package has not been published yet and GitHub Packages returns a not-found response for the latest-version lookup, the workflow falls back to the version in `packages/todo-types/package.json` and bumps that patch value. Other registry lookup failures, including auth or network errors, fail the job instead of using the fallback path.
+The workflow installs only `@jonpham/2026-project-todo-types` and its dependency closure, with lifecycle scripts disabled so unrelated monorepo hooks do not run on the publish path. It then runs package lint/test/build, checks for a commit-scoped version reservation tag, looks up the latest published package version in GitHub Packages when needed, reserves the chosen version for `github.sha`, and publishes that reserved version. If the same commit is rerun, the workflow reuses the existing reservation instead of minting another patch version. It then checks whether that reserved version is already present in GitHub Packages: if it is already present, the workflow skips publish cleanly; if it is not present, the workflow publishes the same reserved version. If the package has not been published yet and GitHub Packages returns a not-found response for the latest-version lookup, the workflow falls back to the version in `packages/todo-types/package.json` and bumps that patch value. Other registry lookup failures, including auth or network errors, fail the job instead of using the fallback path.
 
 The version bump happens inside CI only. The workflow does not commit the bumped `package.json` back to `main`.
 
@@ -27,25 +27,25 @@ No extra publish secret is required when the package is published from this repo
 
 ## Consumer setup
 
-Consumers need GitHub Packages registry configuration for the `@todo-skeleton` scope.
+Consumers need GitHub Packages registry configuration for the `@jonpham` scope.
 
 `.npmrc`
 
 ```ini
-@todo-skeleton:registry=https://npm.pkg.github.com
+@jonpham:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
 ```
 
 Install a published version with pnpm:
 
 ```bash
-pnpm add @todo-skeleton/types@0.1.1
+pnpm add @jonpham/2026-project-todo-types@0.1.1
 ```
 
 Install a published version with npm:
 
 ```bash
-npm install @todo-skeleton/types@0.1.1
+npm install @jonpham/2026-project-todo-types@0.1.1
 ```
 
 For local development in GitHub Actions, set `GITHUB_TOKEN` in the job environment. For developer machines or external repos, use a personal access token with package read access.

--- a/packages/todo-types/.npmrc
+++ b/packages/todo-types/.npmrc
@@ -1,1 +1,1 @@
-@todo-skeleton:registry=https://npm.pkg.github.com
+@jonpham:registry=https://npm.pkg.github.com

--- a/packages/todo-types/package.json
+++ b/packages/todo-types/package.json
@@ -1,8 +1,13 @@
 {
-  "name": "@todo-skeleton/types",
+  "name": "@jonpham/2026-project-todo-types",
   "version": "0.1.0",
   "type": "module",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jonpham/2026-project-todo-skeleton-monorepo.git",
+    "directory": "packages/todo-types"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- Rename the shared types package to `@jonpham/2026-project-todo-types` so GitHub Packages can publish it under the repository owner's namespace.
- Update the publish workflow scope, package filters, registry lookups, and summary output.
- Include the publish workflow and release helper in the `main` push trigger paths so publish fixes can bootstrap or repair the package without unrelated source edits.
- Align W2 docs and follow-on feature docs with the new package name and `@jonpham` registry scope.

## Verification
- `pnpm --filter @jonpham/2026-project-todo-types lint`
- `pnpm --filter @jonpham/2026-project-todo-types test`
- `pnpm --filter @jonpham/2026-project-todo-types build`
- `pnpm --filter @jonpham/2026-project-todo-types pack --pack-destination /tmp`
- Confirmed `@jonpham/2026-project-todo-types` is not yet present in GitHub Packages, so the first qualifying merge should create the initial package version.